### PR TITLE
fix: /fc* 并发安全 + 临时图片清理修复

### DIFF
--- a/main.py
+++ b/main.py
@@ -979,6 +979,7 @@ class Mrfzccl(Star):
         self.player.pop(user_id, None)
         self.original_images.pop(user_id, None)
 
+    # 获取指定房间的比赛锁
     def _get_match_lock(self, room_id: str) -> asyncio.Lock:
         now = time.time()
         self._room_lock_last_used[room_id] = now
@@ -990,6 +991,7 @@ class Mrfzccl(Star):
 
         return lock
 
+    # 判断指定房间是否仍有运行中的比赛任务
     def _room_has_runtime(self, room_id: str) -> bool:
         """判断该 room_id 是否仍有运行态（游戏/比赛任务）"""
         data = self.player.get(room_id)
@@ -1007,6 +1009,7 @@ class Mrfzccl(Star):
 
         return False
 
+    # 清理长期闲置的房间锁，防止内存泄漏
     def _cleanup_stale_room_locks(self, max_idle_hours: int = 24) -> int:
         """清理长期闲置的 room lock，避免锁字典无限增长。"""
         try:
@@ -1031,6 +1034,7 @@ class Mrfzccl(Star):
 
         return removed
 
+    # 安全取消异步任务
     @staticmethod
     def _safe_cancel_task(task: asyncio.Task | None) -> None:
         if not task:
@@ -1041,6 +1045,7 @@ class Mrfzccl(Star):
         except Exception:
             pass
 
+    #  清理指定群组的比赛运行时状态
     def _clear_match_runtime(self, group_id: str) -> None:
         self.match_question_state.pop(group_id, None)
 
@@ -1060,6 +1065,7 @@ class Mrfzccl(Star):
         # 清理当前群的题目状态（防止比赛结束后仍可继续答题）
         self.end_game(group_id)
 
+    # 获取比赛结束原因
     async def _get_match_end_reason(self, match) -> str | None:
         """返回比赛结束原因（time_limit/question_limit），不满足则返回 None。"""
         if not match:
@@ -1097,6 +1103,7 @@ class Mrfzccl(Star):
 
         return None
 
+    # 结束比赛并收集前十名参赛者
     async def _end_match_and_collect_top(self, group_id: str, match) -> tuple[str, int, list]:
         """结束比赛 + 清理运行态 + 返回 Top10 参赛者（已按得分排序），并保存荣誉。"""
         match_name = getattr(match, "match_name", "比赛")
@@ -1117,6 +1124,7 @@ class Mrfzccl(Star):
 
         return match_name, match_id, top_participants
 
+    # 生成下一条提示文本并推进提示计数
     def _next_hint_text_and_advance(self, user_id: str) -> tuple[str, bool]:
         """生成下一条提示，并将 fctn +1（不含任何权限/活跃检查）。
 
@@ -1161,6 +1169,7 @@ class Mrfzccl(Star):
 
         return text, has_more
 
+    # 为当前题目安排超时自动提示
     def _schedule_match_hint(self, group_id: str) -> None:
         """为当前题目安排一次“超时自动提示”。delay<=0 时不启用。"""
         try:
@@ -1186,6 +1195,7 @@ class Mrfzccl(Star):
             self._match_hint_after_delay(group_id, session, delay, float(token))
         )
 
+    # 延迟后执行自动提示的循环任务
     async def _match_hint_after_delay(self, group_id: str, session: str, delay: int, token: float) -> None:
         try:
             interval = max(1, int(delay))


### PR DESCRIPTION
## 摘要
  修复 /fc 系列指令在并发触发时可能出现的多次处理/状态竞争问题；同时修复定时清理图片时报错（`'str' object has no attribute 'glob'`），并为房间锁增加闲置回收机
  制，避免长期运行导致锁字典无限增长。

  ## 背景 / 问题
  - `/fc`、`/fcc`、`/fct`、`/fce`、`/fcw` 在同一群/同一私聊里被同时触发时，会对共享状态（如 `self.player`、提示计数、比赛切题/结束逻辑）产生竞争，可能引发数据
  错误或重复处理。
  - `_cleanup_old_images` 中使用 `self.img_tmp_path.glob("*.png")`，但 `img_tmp_path` 实际为 `str`，导致清理任务报错并无法工作。
  - 由于这些指令是 async generator（使用 `yield` 返回消息），如果在 `async with lock:` 内 `yield`，锁可能会被持有到生成器结束，造成房间内其它命令/后台任务被阻
  塞。
  - 以 room_id（群号/私聊 user_id）为 key 的锁容器若不回收，长期运行且服务大量私聊用户时会逐步增长。

  ## 变更内容
  - 并发控制（房间级别）：
    - 为同一 room_id（群聊用 group_id，私聊用 sender_id）引入 `asyncio.Lock`，串行化 `/fc*` 指令对共享状态的读写，防止竞争导致的多次处理。
  - 避免“持锁 yield”：
    - 在锁内仅做共享状态/DB 更新与响应内容组装；退出锁后再 `yield`/发送，避免 async generator 暂停导致锁长期占用。
  - 图片清理修复：
    - `img_tmp_path` 改为 `pathlib.Path`，并在初始化渲染器时传入 `str(img_tmp_path)`，保证 `.glob("*.png")` 可用。
  - 锁回收（防止无限增长）：
    - 记录每个 room lock 的最近使用时间；在定时清理任务中按 idle TTL（默认 24h）回收“未锁定且无运行态”的闲置锁。

  ## 配置变更
  - 无

  ## 风险 / 兼容性说明
  - 同一房间内的 `/fc*` 指令会排队执行（预期行为：用吞吐换一致性，避免状态错乱）。
  - 锁回收仅针对“长期闲置 + 无运行态 + 未锁定”的 room，避免误删仍在使用的房间锁。

  ## 测试
  - 未新增自动化测试。
  - 建议手动验证：
    - 同一群内快速/并发发送 `/fc`、`/fcc xxx`、`/fct`、`/fcw`、`/fce`，确认不会出现重复发题/重复结算/提示计数错乱。
    - 等待定时清理周期后观察日志：不再出现 `str has no attribute glob`，临时图片可正常清理。

## Summary by Sourcery

Ensure /fc* commands are room-level concurrency-safe, fix temporary image cleanup, and add idle room lock reclamation.

Bug Fixes:
- Prevent concurrent /fc* commands in the same room from corrupting shared game or match state.
- Fix temporary image cleanup by using a Path-based tmp directory compatible with glob-based file scans.

Enhancements:
- Introduce room-scoped asyncio locks with last-used tracking to serialize game/match operations and avoid holding locks across async generator yields.
- Add periodic cleanup of long-idle room locks with no active runtime state to prevent unbounded memory growth.
- Improve match and hint helper methods with clearer responsibilities such as determining match end reasons and scheduling hints.