### PR TITLE
feat:添加图获取重试机制

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 更新日志
 
+### 1.2.15
+- ✅ 修复 `image_download_retry` 被错误配置为非对象时可能导致插件启动失败的问题
+
 ### 1.2.14
 - ✅ 将图片下载重试配置收口为 `image_download_retry` 对象
 - ✅ 新增图片下载重试间隔秒数配置 `retry_interval_seconds`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## 更新日志
 
+### 1.2.14
+- ✅ 将图片下载重试配置收口为 `image_download_retry` 对象
+- ✅ 新增图片下载重试间隔秒数配置 `retry_interval_seconds`
+
+### 1.2.13
+- ✅ 为 bilibili wiki 图片获取增加失败重试机制
+- ✅ 新增 `image_download_max_retries` 配置项，可设置图片下载最大重试次数
+
 ### 1.2.12
 - ✅ 统一清理日志与命令行打包脚本中的英文自然语言文本，改为中文表述
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ AstrBot 插件：遮挡干员立绘猜名字；支持排行榜、名片、比赛
 ## 配置（`_conf_schema.json`）
 
 - `mrfz_data_path`: 题库 JSON 路径（默认 `arknights_skins_dict.json`）
+- `image_download_retry`: bilibili wiki 图片下载重试配置（包含最大重试次数和重试间隔秒数）
 - `target_size`: 输出图片参考大小
 - `easy_probability` / `medium_probability` / `hard_probability`: 难度概率
 - `similarity_threshold`: 相似度阈值（SequenceMatcher）

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -11,6 +11,23 @@
     "default": "arknights_operator_aliases.json",
     "hint": "例如：/home/user/arknights_operator_aliases.json"
   },
+  "image_download_retry": {
+    "description": "bilibili wiki 图片下载重试设置",
+    "type": "object",
+    "hint": "用于控制图片获取失败后的最大重试次数和每次重试之间的等待时间",
+    "items": {
+      "max_retries": {
+        "description": "最大重试次数",
+        "type": "int",
+        "default": 2
+      },
+      "retry_interval_seconds": {
+        "description": "重试间隔秒数",
+        "type": "float",
+        "default": 0.5
+      }
+    }
+  },
   "target_size": {
     "description": "角色立绘最后输出的参考大小",
     "type": "int",

--- a/main.py
+++ b/main.py
@@ -80,6 +80,8 @@ class Mrfzccl(Star):
         )
         # 下载 bilibili wiki 图片时的重试配置
         image_download_retry = self.Config.get("image_download_retry", {}) or {}
+        if not isinstance(image_download_retry, dict):
+            image_download_retry = {}
         self.image_download_max_retries = max(
             0,
             int(

--- a/main.py
+++ b/main.py
@@ -16,20 +16,19 @@ from .src.tool import (
 )
 from .src.db.repo import UserQnARepo, MatchRepo
 from .src.db.database import DBManager
-
 from .src.handlers import ccl_admin, ccl_leaderboard, ccl_match, fc_handlers
 
 from typing import Optional, Dict, Any, Tuple, List
 from datetime import datetime, timedelta
 from urllib.parse import urlparse
-from io import BytesIO
 from pathlib import Path
+from io import BytesIO
 from PIL import Image
 import numpy as np
 import traceback
+import ipaddress
 import asyncio
 import aiohttp
-import ipaddress
 import random
 import json
 import time
@@ -78,6 +77,22 @@ class Mrfzccl(Star):
         # 是否启用干员别名精确判题
         self.enable_operator_alias_match = self.Config.get(
             "enable_operator_alias_match", True
+        )
+        # 下载 bilibili wiki 图片时的重试配置
+        image_download_retry = self.Config.get("image_download_retry", {}) or {}
+        self.image_download_max_retries = max(
+            0,
+            int(
+                image_download_retry.get(
+                    "max_retries",
+                    self.Config.get("image_download_max_retries", 2),
+                )
+                or 0
+            ),
+        )
+        self.image_download_retry_interval_seconds = max(
+            0.0,
+            float(image_download_retry.get("retry_interval_seconds", 0.5) or 0.0),
         )
 
         # 每日限制配置
@@ -1139,53 +1154,74 @@ class Mrfzccl(Star):
     async def get_image_from_url(
         self, url: str, timeout: int = 10
     ) -> Optional[Image.Image]:
-        try:
-            # 检查URL协议
-            if not url.startswith(("http://", "https://")):
-                raise ValueError(f"无效的URL协议: {url}")
+        # 检查URL协议
+        if not url.startswith(("http://", "https://")):
+            raise ValueError(f"无效的URL协议: {url}")
 
-            # 安全检查：防止访问内网地址
-            parsed_url = urlparse(url)
-            hostname = parsed_url.hostname
-            if hostname:
-                hostname_norm = str(hostname).strip().lower()
-                if hostname_norm == "localhost":
-                    raise ValueError(f"禁止访问内网地址: {hostname}")
-                try:
-                    ip = ipaddress.ip_address(hostname_norm)
-                except ValueError:
-                    ip = None
-                if ip and not ip.is_global:
-                    raise ValueError(f"禁止访问内网地址: {hostname}")
+        # 安全检查：防止访问内网地址
+        parsed_url = urlparse(url)
+        hostname = parsed_url.hostname
+        if hostname:
+            hostname_norm = str(hostname).strip().lower()
+            if hostname_norm == "localhost":
+                raise ValueError(f"禁止访问内网地址: {hostname}")
+            try:
+                ip = ipaddress.ip_address(hostname_norm)
+            except ValueError:
+                ip = None
+            if ip and not ip.is_global:
+                raise ValueError(f"禁止访问内网地址: {hostname}")
 
-            # 获取HTTP会话
-            session = await self._get_session()
-            async with session.get(
-                url,
-                ssl=False,  # 忽略SSL证书验证
-            ) as response:
-                if response.status != 200:
-                    raise Exception(f"HTTP {response.status}: {response.reason}")
+        max_attempts = max(1, int(getattr(self, "image_download_max_retries", 2)) + 1)
+        last_error: Exception | None = None
 
-                # 读取响应内容
-                content = await response.read()
-                if len(content) == 0:
-                    raise Exception("下载的图片数据为空")
-                if len(content) > 10 * 1024 * 1024:  # 限制10MB
-                    raise Exception("图片文件过大")
+        for attempt in range(1, max_attempts + 1):
+            try:
+                # 获取HTTP会话
+                session = await self._get_session()
+                async with session.get(
+                    url,
+                    ssl=False,  # 忽略SSL证书验证
+                ) as response:
+                    if response.status != 200:
+                        raise Exception(f"HTTP {response.status}: {response.reason}")
 
-                # 在线程池中加载图片
-                loop = asyncio.get_running_loop()
-                image = await loop.run_in_executor(
-                    None, self._load_image_from_bytes, content
+                    # 读取响应内容
+                    content = await response.read()
+                    if len(content) == 0:
+                        raise Exception("下载的图片数据为空")
+                    if len(content) > 10 * 1024 * 1024:  # 限制10MB
+                        raise Exception("图片文件过大")
+
+                    # 在线程池中加载图片
+                    loop = asyncio.get_running_loop()
+                    image = await loop.run_in_executor(
+                        None, self._load_image_from_bytes, content
+                    )
+                    return image
+            except ValueError:
+                raise
+            except (aiohttp.ClientError, Exception) as e:
+                last_error = e
+                if attempt >= max_attempts:
+                    break
+                logger.warning(
+                    f"[get_image_from_url] 获取 bilibili wiki 图片失败，准备重试 "
+                    f"({attempt}/{max_attempts - 1}): {e}"
                 )
-                return image
-        except (aiohttp.ClientError, ValueError) as e:
-            logger.error(f"[get_image_from_url] 请求失败: {e}")
-            raise
-        except Exception as e:
-            logger.error(f"[get_image_from_url] 处理图片时出错: {e}")
-            raise
+                retry_interval = float(
+                    getattr(self, "image_download_retry_interval_seconds", 0.0) or 0.0
+                )
+                if retry_interval > 0:
+                    await asyncio.sleep(retry_interval)
+
+        if isinstance(last_error, aiohttp.ClientError):
+            logger.error(f"[get_image_from_url] 请求失败: {last_error}")
+            raise last_error
+        if last_error is not None:
+            logger.error(f"[get_image_from_url] 处理图片时出错: {last_error}")
+            raise last_error
+        raise RuntimeError("获取图片失败，未捕获到具体错误")
 
     # 同步加载图片（在线程池中执行）
     def _load_image_from_bytes(self, content: bytes) -> Image.Image:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 name: astrbot_plugin_mrfzccl # 插件唯一识别名，以 astrbot_plugin_ 前缀开头
 display_name: 明日方舟猜猜乐 # 用于展示的名字，可以是方便人类阅读的名字（需要版本 >= v4.5.0，低版本不会报错，请放心填写）
 desc: 明日方舟干员立绘猜猜乐，支持排行榜/名片/比赛模式 # 插件简短描述
-version: v1.2.14 # 插件版本号。格式：v1.1.1 或者 v1.1
+version: v1.2.15 # 插件版本号。格式：v1.1.1 或者 v1.1
 author: lishining # 作者
 repo: https://github.com/Li-shi-ling/astrbot_plugin_mrfzccl # 插件的仓库地址
 support_platforms:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 name: astrbot_plugin_mrfzccl # 插件唯一识别名，以 astrbot_plugin_ 前缀开头
 display_name: 明日方舟猜猜乐 # 用于展示的名字，可以是方便人类阅读的名字（需要版本 >= v4.5.0，低版本不会报错，请放心填写）
 desc: 明日方舟干员立绘猜猜乐，支持排行榜/名片/比赛模式 # 插件简短描述
-version: v1.2.12 # 插件版本号。格式：v1.1.1 或者 v1.1
+version: v1.2.14 # 插件版本号。格式：v1.1.1 或者 v1.1
 author: lishining # 作者
 repo: https://github.com/Li-shi-ling/astrbot_plugin_mrfzccl # 插件的仓库地址
 support_platforms:


### PR DESCRIPTION
## 概要

主要解决了 bilibili wiki 图片获取不稳定时缺少重试的问题。

## 变更内容

### 1. 为 bilibili wiki 图片下载增加失败重试能力

在图片下载链路中增加失败重试逻辑：

- 当获取 bilibili wiki 图片失败时，会按配置自动重试
- 本地校验类错误（如非法 URL、内网地址）不会重试
- 网络错误、HTTP 异常、空内容、图片处理异常等会进入重试逻辑

相关实现位于：

- `main.py`

### 2. 将图片下载重试配置收口为对象配置

新增对象型配置：

- `image_download_retry`

其内部包含两个子项：

- `max_retries`
  - 最大重试次数
- `retry_interval_seconds`
  - 每次重试之间的等待秒数

### 3. 兼容旧配置读取

代码对新旧配置做了兼容处理：

- 优先读取对象配置 `image_download_retry.max_retries`
- 若对象配置缺失，仍兼容旧的扁平配置 `image_download_max_retries`

## 影响文件

本次主要修改了以下文件：

- `main.py`
- `_conf_schema.json`
- `README.md`
- `metadata.yaml`
- `CHANGELOG.md`

## Summary by Sourcery

Add configurable retry support for fetching bilibili wiki images and update related metadata and documentation.

New Features:
- Introduce configurable retry logic for bilibili wiki image downloads, including maximum retries and retry interval.

Enhancements:
- Consolidate image download retry settings into a single image_download_retry object while maintaining backward compatibility with existing flat configuration.

Documentation:
- Document the new image_download_retry configuration and its parameters in the README.
- Record the new image download retry feature and configuration changes in the changelog.

Chores:
- Bump plugin version metadata to v1.2.14.